### PR TITLE
add message management

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -3,6 +3,7 @@ import discord
 import os
 from discord.ext import commands
 from dotenv import load_dotenv
+from database.message_management import setup_sticky_handler
 from session import init_db
 from modals import CubeSelectionModal
 from utils import cleanup_sessions_task
@@ -56,6 +57,8 @@ async def main():
     await swiss_draft_commands(bot)
     await init_db()
     logger.info("Database initialized")
+
+    await setup_sticky_handler(bot)
 
     # Run the bot
     await bot.start(TOKEN)

--- a/database/message_management.py
+++ b/database/message_management.py
@@ -1,0 +1,162 @@
+from typing import Optional
+import discord
+from sqlalchemy import JSON, Column, Integer, String, Boolean, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from views import PersistentView
+from database.models_base import Base
+from session import AsyncSessionLocal, DraftSession, get_draft_session
+from loguru import logger
+
+STICKY_MESSAGE_BUFFER = 5
+
+class Message(Base):
+    """Represents a message stored in the database, potentially a sticky message."""
+    __tablename__ = 'messages'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    guild_id = Column(String(64), nullable=False)
+    channel_id = Column(String(64), nullable=False)
+    message_id = Column(String(64), nullable=False)
+    content = Column(String, nullable=False)
+    view_metadata = Column(JSON, nullable=True)
+    is_sticky = Column(Boolean, default=False)
+    message_count = Column(Integer, default=0)
+
+    def __repr__(self) -> str:
+        return (
+            f"<Message(guild_id={self.guild_id}, channel_id={self.channel_id}, "
+            f"message_id={self.message_id}, is_sticky={self.is_sticky})>"
+        )
+
+
+async def fetch_sticky_message(channel_id: str, session: AsyncSession) -> Optional[Message]:
+    """Fetches the sticky message for a given channel from the database."""
+    result = await session.execute(
+        select(Message).filter_by(channel_id=channel_id, is_sticky=True)
+    )
+    return result.scalars().first()
+
+
+async def update_draft_session_message(draft_session_id: str, message_id: str, session: AsyncSession) -> None:
+    """Updates the draft session with a new sticky message ID."""
+    draft_session = await get_draft_session(draft_session_id)
+    if not draft_session:
+        logger.error(f"DraftSession with ID {draft_session_id} not found in database.")
+        return
+
+    draft_session.message_id = message_id
+    session.add(draft_session)
+    session.commit()
+
+
+async def handle_sticky_message_update(sticky_message: Message, bot: discord.Client, session: AsyncSession) -> None:
+    """Handles the process of updating and pinning the sticky message in Discord."""
+    draft_session_id = sticky_message.view_metadata.get("draft_session_id")
+    if not draft_session_id:
+        logger.error("Missing draft_session_id in view_metadata.")
+        return
+
+    channel = await bot.fetch_channel(int(sticky_message.channel_id))
+    try:
+        draft_message = await channel.fetch_message(int(sticky_message.message_id))
+        embed = draft_message.embeds[0] if draft_message.embeds else None
+    except discord.NotFound:
+        logger.warning(f"Sticky message with ID {sticky_message.message_id} not found.")
+        return
+
+    view = PersistentView.from_metadata(bot, sticky_message.view_metadata)
+    old_message = await channel.fetch_message(int(sticky_message.message_id))
+    new_message = await channel.send(content=sticky_message.content, embed=embed, view=view)
+    await new_message.pin()
+    logger.info(f"Pinned new sticky message with ID {new_message.id} in channel {channel.id}")
+
+    sticky_message.message_id = str(new_message.id)
+    await update_draft_session_message(draft_session_id, str(new_message.id), session)
+
+    if old_message:
+        await old_message.delete()
+        logger.info(f"Deleted old sticky message with ID {old_message.id}")
+
+
+async def setup_sticky_handler(bot: discord.Client) -> None:
+    """Sets up event handlers for managing sticky messages in Discord."""
+    logger.info("Setting up sticky message handler")
+
+    @bot.event
+    async def on_message(message: discord.Message) -> None:
+        if message.author.bot:
+            return
+
+        async with AsyncSessionLocal() as session:
+            async with session.begin():
+                sticky_message = await fetch_sticky_message(str(message.channel.id), session)
+                if not sticky_message:
+                    logger.debug(f"No sticky message found for channel {message.channel.id}")
+                    return
+
+                # Increment message count and check if it meets the buffer limit
+                sticky_message.message_count += 1
+                if sticky_message.message_count < STICKY_MESSAGE_BUFFER:
+                    await session.commit()  # Commit to save the incremented message count
+                    logger.info(f"Buffer not met ({sticky_message.message_count}/{STICKY_MESSAGE_BUFFER}). Not updating sticky message.")
+                    return
+
+                # Reset count after buffer is met
+                sticky_message.message_count = 0
+                await handle_sticky_message_update(sticky_message, bot, session)
+
+    @bot.event
+    async def on_message_unpin(message: discord.Message) -> None:
+        await remove_sticky_message(message)
+
+    @bot.event
+    async def on_message_delete(message: discord.Message) -> None:
+        await remove_sticky_message(message)
+
+
+async def make_message_sticky(
+    guild_id: str, channel_id: str, message: discord.Message, view: PersistentView
+) -> None:
+    """Pins a message in a channel and saves it as sticky in the database."""
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            existing_sticky = await fetch_sticky_message(channel_id, session)
+            view_metadata = view.to_metadata()
+            if not message.pinned:
+                await message.pin()
+                logger.info(f"Pinned message ID {message.id} in channel {channel_id} as sticky.")
+
+            if existing_sticky:
+                existing_sticky.message_id = str(message.id)
+                existing_sticky.content = message.content
+                existing_sticky.view_metadata = view_metadata
+                existing_sticky.message_count = 0  # Reset counter on update
+                logger.info(f"Updated sticky message in database for channel {channel_id}.")
+            else:
+                new_message = Message(
+                    guild_id=guild_id,
+                    channel_id=channel_id,
+                    message_id=str(message.id),
+                    content=message.content,
+                    view_metadata=view_metadata,
+                    is_sticky=True,
+                    message_count=0,  # Initialize counter
+                )
+                session.add(new_message)
+                logger.info(f"Created new sticky message entry for channel {channel_id}.")
+
+        await session.commit()
+        logger.info(f"Sticky message ID {message.id} committed for channel {channel_id}")
+
+
+async def remove_sticky_message(message: discord.Message) -> None:
+    """Removes a sticky message from the database if it matches the given message."""
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            sticky_message = await fetch_sticky_message(str(message.channel.id), session)
+            if not sticky_message or sticky_message.message_id != str(message.id):
+                return
+
+            await session.delete(sticky_message)
+            logger.info(f"Removed sticky message with ID {message.id} from channel {message.channel.id} in database.")
+        await session.commit()

--- a/database/models_base.py
+++ b/database/models_base.py
@@ -1,0 +1,5 @@
+# models_base.py
+from sqlalchemy.orm import declarative_base
+
+# Define the shared Base
+Base = declarative_base()

--- a/session.py
+++ b/session.py
@@ -1,7 +1,8 @@
 import discord
 from sqlalchemy import Column, Integer, String, DateTime, JSON, select, Boolean, ForeignKey, desc, Float, func
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
-from sqlalchemy.orm import sessionmaker, relationship, declarative_base
+from sqlalchemy.orm import sessionmaker, relationship
+from database.models_base import Base
 from datetime import datetime
 import logging
 
@@ -23,8 +24,6 @@ async def init_db():
 
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
-
-Base = declarative_base()
 
 class DraftSession(Base):
     __tablename__ = 'draft_sessions'

--- a/sessions/base_session.py
+++ b/sessions/base_session.py
@@ -1,3 +1,4 @@
+from database.message_management import make_message_sticky
 from models.session_details import SessionDetails
 from session import DraftSession, AsyncSessionLocal
 from datetime import datetime, timedelta
@@ -11,10 +12,11 @@ class BaseSession:
     async def create_draft_session(self, interaction, bot):
         async with AsyncSessionLocal() as session:
             async with session.begin():
+                # Step 1: Set up the draft session
                 new_draft_session = self.setup_draft_session(session)
                 await session.commit()
 
-                # Handling Embed and View
+                # Step 2: Create Embed and Persistent View
                 embed = self.create_embed()
                 view = PersistentView(
                     bot=bot,
@@ -25,12 +27,14 @@ class BaseSession:
                 )
                 await interaction.response.send_message(embed=embed, view=view)
 
-                # Update the draft session with message information
+                # Step 3: Get the original response message to set as sticky
                 message = await interaction.original_response()
+
+                # Step 4: Update the draft session with message information
                 await self.update_message_info(new_draft_session, message)
 
-                # Pin the message to the channel
-                await message.pin()
+                # Step 5: Make the message sticky (replace pinning with sticky logic)
+                await make_message_sticky(interaction.guild.id, message.channel.id, message, view)
 
     def setup_draft_session(self, session):
         new_draft_session = DraftSession(


### PR DESCRIPTION
## Summary
This PR adds sticky message functionality to DraftBot, allowing draft session messages to persist at the bottom of the channel. These messages, including embeds and interactive views, are automatically re-sent whenever new messages are posted to ensure key information remains visible and actionable.

Additionally, the `models_base` has been refactored into its own file to improve code organization, particularly with the introduction of the `Message` model used to support sticky messages.

## Why
- **Sticky Messages**: To enhance the user experience by keeping important draft-related messages consistently accessible without manual pinning.
- **Model Refactor**: To improve code structure and maintainability by moving the model base into its own dedicated module.
